### PR TITLE
init: Fix vendor mismatch error

### DIFF
--- a/init/init_yoshino.cpp
+++ b/init/init_yoshino.cpp
@@ -92,7 +92,16 @@ static void load_properties(char *data, const char *filter)
                     if (strcmp(key, filter)) continue;
                 }
             }
-            property_override(key, value);
+            if (strcmp(key, "ro.build.description") == 0
+                || strcmp(key, "ro.build.version.incremental") == 0
+                || strcmp(key, "ro.build.tags") == 0
+                || strcmp(key, "ro.build.fingerprint") == 0
+                || strcmp(key, "ro.vendor.build.fingerprint") == 0
+                || strcmp(key, "ro.bootimage.build.fingerprint") == 0) {
+                LOG(INFO) << "Skipped prop: " << key;
+            } else {
+                property_override(key, value);
+            }
         }
     }
 }


### PR DESCRIPTION
Discard loading of set of props that overrides the build prop(s)
of vendor (and other small components) causing the mismatch error.